### PR TITLE
fix(terraform): fix deployment workflow

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -1,0 +1,38 @@
+name: apply
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Published tag (e.g. v1.0.0)"
+        required: true
+
+env:
+  TERRAFORM_VERSION: 0.14.3
+
+jobs:
+  release:
+    name: Release
+    defaults:
+      run:
+        working-directory: terraform
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      - name: Set image_tag
+        run: |
+          tag=$(echo "${{ github.event.inputs.tag }}" | sed "s/^v//")
+          if [ -z "$tag" ]; then
+            exit 1
+          fi
+          echo 'image_tag = "$tag"' >> release.auto.tfvars
+      - name: Init
+        run: terraform init
+      - name: Validate
+        run: terraform validate -no-color
+      - name: Apply
+        run: terraform apply -no-color

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,17 +5,12 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Release tag (e.g. v1.0.0)"
-        required: true
-
 env:
   DOCKER_REPO: ww24/calendar-notifier
   GAR_REPOSITORY: ww24
   IMAGE_NAME: calendar-notifier
   GCP_LOCATION: asia-northeast1
+  TERRAFORM_VERSION: 0.14.3
 
 jobs:
   lint:
@@ -98,26 +93,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: trivy-results.sarif
-      - name: Set image tag
-        if: github.event_name != 'workflow_dispatch'
+      - name: Output image tag
+        id: tag
         run: |
           tag=$(echo "${GITHUB_REF}" | sed "s/^refs\/tags\/v//")
           if [ -z "$tag" ]; then
             exit 1
           fi
-          echo "IMAGE_TAG=$tag" >> $GITHUB_ENV
-      - name: Set image tag (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          tag=$(echo "${{ github.event.inputs.tag }}" | sed "s/^v//")
-          if [ -z "$tag" ]; then
-            exit 1
-          fi
-          echo "IMAGE_TAG=$tag" >> $GITHUB_ENV
-      - name: Output image tag
-        id: tag
-        run: |
-          echo "::set-output name=image_tag::$IMAGE_TAG"
+          echo "::set-output name=image_tag::$tag"
 
   docker_push:
     needs: [lint, test, docker_build]
@@ -198,7 +181,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.3
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
       - name: Set image_tag
         run: |

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -12,6 +12,7 @@ env:
   DOCKER_REPO: ww24/calendar-notifier
   IMAGE_NAME: calendar-notifier
   IMAGE_TAG: latest
+  TERRAFORM_VERSION: 0.14.3
 
 jobs:
   lint:
@@ -142,7 +143,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.3
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
       - name: Fmt
         run: terraform fmt -check

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ calendar-notifier
 ===
 
 [![Go Reference][go-dev-img]][go-dev-url]
-![Test on master][github-actions-img]
+![test-and-build][github-actions-img]
 
 Calendar Notifier provides event handler and actions triggered by Google Calendar.
 


### PR DESCRIPTION
workflow_dispatch event を `apply.yml` として分離。
新しく docker image をアップロードせず、既存のイメージを使用して apply するよう修正。

cf. https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/