### PR TITLE
fix(terraform): set autogenerate_revision_name

### DIFF
--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -49,4 +49,6 @@ resource "google_cloud_run_service" "calendar_notifier" {
     percent         = 100
     latest_revision = true
   }
+
+  autogenerate_revision_name = true
 }


### PR DESCRIPTION
Set autogenerate_revision_name.

Fix an error below.
```
googleapi: Error 409: Revision named 'calendar-notifier-00016-vet' with different configuration already exists.
```

cf. https://registry.terraform.io/providers/hashicorp/google/3.51.1/docs/resources/cloud_run_service#autogenerate_revision_name