### PR TITLE
ci: fix GitHub Container Registry login password

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -118,7 +118,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push docker image


### PR DESCRIPTION
`secrets.GITHUB_TOKEN` を使用するよう修正。